### PR TITLE
Non-null context object

### DIFF
--- a/src/pollKinesis.js
+++ b/src/pollKinesis.js
@@ -15,7 +15,7 @@ module.exports = (kinesis, StreamName, logger) => {
   const reduceRecord = lambda => (promise, kinesisRecord) => promise.then(() => {
     const singleRecordEvent = { Records: [{ kinesis: mapKinesisRecord(kinesisRecord) }] };
     logger.log('Invoking lambda with record from stream:', JSON.stringify(singleRecordEvent));
-    return lambda(singleRecordEvent, null, callback);
+    return lambda(singleRecordEvent, {}, callback);
   });
 
   const pollKinesis = lambda => (firstShardIterator) => {


### PR DESCRIPTION
In order to more closely match AWS Lambda - pass an empty context object to the lambda rather than null.

This prevents problems e.g. with [middy](https://github.com/middyjs/middy), which expects a non-null context.